### PR TITLE
Attempt plugin load from global symbol table

### DIFF
--- a/inc/libfunctionality/Common.h
+++ b/inc/libfunctionality/Common.h
@@ -100,7 +100,8 @@ typedef char libfunc_ep_return_t;
 /** @brief The string name of the common entry point.
     @todo make this use c preproc stringize while dodging portability problems.
  */
-#define LIBFUNC_DETAIL_EP_COMMON_NAME_STRING "libfunc_entry_point"
+#define LIBFUNC_DETAIL_EP_COMMON_NAME_STRING                                   \
+    LIBFUNC_DETAIL_STRINGIFY(LIBFUNC_DETAIL_EP_COMMON_NAME)
 
 /** @brief Declaration of the common entry point used in dynamic mode. */
 #define LIBFUNC_DETAIL_EP_COMMON_DECLARATION                                   \

--- a/inc/libfunctionality/Common.h
+++ b/inc/libfunctionality/Common.h
@@ -64,6 +64,12 @@ Copyright 2014 Sensics, Inc.
 /** @brief Utility macro for token pasting aka concatenation */
 #define LIBFUNC_DETAIL_CAT(A, B) LIBFUNC_DETAIL_CAT_IMPL(A##B)
 
+/** @brief Utility macro used in stringification of macros. */
+#define LIBFUNC_DETAIL_STRINGIFY_IMPL(X) #X
+
+/** @brief Utility macro forstringification of macro expansions. */
+#define LIBFUNC_DETAIL_STRINGIFY(X) LIBFUNC_DETAIL_STRINGIFY_IMPL(X)
+
 /** @brief The prefix appended to a plugin name to generate a unique entry point
  * name. */
 #define LIBFUNC_DETAIL_EP_PREFIX libfunc_ep_

--- a/inc/libfunctionality/Common.h
+++ b/inc/libfunctionality/Common.h
@@ -74,9 +74,14 @@ Copyright 2014 Sensics, Inc.
  * name. */
 #define LIBFUNC_DETAIL_EP_PREFIX libfunc_ep_
 
+/** @brief Utility macro (second-level expansion) for unique entry point
+ * generation */
+#define LIBFUNC_DETAIL_EP_NAME_IMPL(X, PLUGINNAME)                             \
+    LIBFUNC_DETAIL_CAT(X, PLUGINNAME)
+
 /** @brief Generate the unique entry point name for each plugin. */
 #define LIBFUNC_DETAIL_EP_NAME(PLUGINNAME)                                     \
-    LIBFUNC_DETAIL_CAT(LIBFUNC_DETAIL_EP_PREFIX, PLUGINNAME)
+    LIBFUNC_DETAIL_EP_NAME_IMPL(LIBFUNC_DETAIL_EP_PREFIX, PLUGINNAME)
 
 /** @brief Return type of the entry point function. */
 typedef char libfunc_ep_return_t;

--- a/inc/libfunctionality/Common.h
+++ b/inc/libfunctionality/Common.h
@@ -64,9 +64,13 @@ Copyright 2014 Sensics, Inc.
 /** @brief Utility macro for token pasting aka concatenation */
 #define LIBFUNC_DETAIL_CAT(A, B) LIBFUNC_DETAIL_CAT_IMPL(A##B)
 
+/** @brief The prefix appended to a plugin name to generate a unique entry point
+ * name. */
+#define LIBFUNC_DETAIL_EP_PREFIX libfunc_ep_
+
 /** @brief Generate the unique entry point name for each plugin. */
 #define LIBFUNC_DETAIL_EP_NAME(PLUGINNAME)                                     \
-    LIBFUNC_DETAIL_CAT(libfunc_ep_, PLUGINNAME)
+    LIBFUNC_DETAIL_CAT(LIBFUNC_DETAIL_EP_PREFIX, PLUGINNAME)
 
 /** @brief Return type of the entry point function. */
 typedef char libfunc_ep_return_t;

--- a/inc/libfunctionality/Common.h
+++ b/inc/libfunctionality/Common.h
@@ -67,7 +67,7 @@ Copyright 2014 Sensics, Inc.
 /** @brief Utility macro used in stringification of macros. */
 #define LIBFUNC_DETAIL_STRINGIFY_IMPL(X) #X
 
-/** @brief Utility macro forstringification of macro expansions. */
+/** @brief Utility macro for stringification of macro expansions. */
 #define LIBFUNC_DETAIL_STRINGIFY(X) LIBFUNC_DETAIL_STRINGIFY_IMPL(X)
 
 /** @brief The prefix appended to a plugin name to generate a unique entry point

--- a/inc/libfunctionality/PluginInterface.h
+++ b/inc/libfunctionality/PluginInterface.h
@@ -59,7 +59,7 @@ Copyright 2014 Sensics, Inc.
  * In dynamic mode, we have to create the common entry point as a trampoline to
  * the unique one. */
 #define LIBFUNC_DETAIL_PLUGIN(PLUGINNAME)                                      \
-    LIBFUNC_DETAIL_EP_DECLARATION(PLUGINNAME);                                 \
+    LIBFUNC_DETAIL_EP_DECORATION LIBFUNC_DETAIL_EP_DECLARATION(PLUGINNAME);                                 \
     LIBFUNC_DETAIL_EP_DECORATION LIBFUNC_DETAIL_EP_COMMON_DECLARATION {        \
         return LIBFUNC_DETAIL_EP_NAME(PLUGINNAME)(LIBFUNC_DETAIL_PARAM_NAME);  \
     }

--- a/src/libfunctionality/LoadPluginLibdl.h
+++ b/src/libfunctionality/LoadPluginLibdl.h
@@ -55,7 +55,8 @@ PluginHandle loadPluginByName(std::string const &n, void *opaque) {
     // attempt to load the symbol from the global symbol table. If successful,
     // plugin is already pre-loaded
     {
-        std::string ep_name = std::string("libfunc_ep_") + n;
+        std::string ep_name =
+            std::string(LIBFUNC_DETAIL_STRINGIFY(LIBFUNC_DETAIL_EP_PREFIX)) + n;
         DlsymReturn raw_ep;
         dlerror(); // clear the error
         *(void **)(&raw_ep) = dlsym(RTLD_DEFAULT, ep_name.c_str());

--- a/src/libfunctionality/LoadPluginLibdl.h
+++ b/src/libfunctionality/LoadPluginLibdl.h
@@ -45,13 +45,29 @@ PluginHandle loadPluginByName(const char *n, void *opaque) {
     return loadPluginByName(std::string(n), opaque);
 }
 
+typedef void *(*DlsymReturn)();
+
+/// internal helper function used by both the global symbol table entry point
+/// path as well as the load from the dlopened handle path
+static inline entry_point_t convertAndCallEntryPoint(std::string const &n,
+                                                     DlsymReturn raw_ep,
+                                                     void *opaque) {
+    entry_point_t ep = reinterpret_cast<entry_point_t>(raw_ep);
+    if (ep == NULL) {
+        throw exceptions::CannotLoadEntryPoint(n);
+    }
+    libfunc_ep_return_t result = (*ep)(opaque);
+    if (result != LIBFUNC_RETURN_SUCCESS) {
+        throw exceptions::PluginEntryPointFailed(n);
+    }
+    return ep;
+}
+
 PluginHandle loadPluginByName(std::string const &n, void *opaque) {
     if (n.empty()) {
         throw exceptions::BadPluginName();
     }
 
-    typedef void *(*DlsymReturn)();
-    
     // attempt to load the symbol from the global symbol table. If successful,
     // plugin is already pre-loaded
     {
@@ -61,13 +77,11 @@ PluginHandle loadPluginByName(std::string const &n, void *opaque) {
         dlerror(); // clear the error
         *(void **)(&raw_ep) = dlsym(RTLD_DEFAULT, ep_name.c_str());
 
-        const char* err = dlerror();
+        const char *err = dlerror();
         if (err == NULL && raw_ep != NULL) {
-            entry_point_t ep = reinterpret_cast<entry_point_t>(raw_ep);
-            libfunc_ep_return_t result = (*ep)(opaque);
-            if (result != LIBFUNC_RETURN_SUCCESS) {
-                throw exceptions::PluginEntryPointFailed(n);
-            }
+            convertAndCallEntryPoint(n, raw_ep, opaque);
+            // Yes, returning an empty PluginHandle here works fine, since it's
+            // just for lifetime management.
             return PluginHandle();
         }
     }
@@ -87,26 +101,13 @@ PluginHandle loadPluginByName(std::string const &n, void *opaque) {
 /// Posix-recommended,
 /// the other is simpler C++.
     {
-#if 1
         DlsymReturn raw_ep;
         *(void **)(&raw_ep) =
             dlsym(lib.get(), LIBFUNC_DETAIL_EP_COMMON_NAME_STRING);
         if (dlerror() != NULL || raw_ep == NULL) {
             throw exceptions::CannotLoadEntryPoint(n);
         }
-        entry_point_t ep = reinterpret_cast<entry_point_t>(raw_ep);
-#else
-        entry_point_t ep = reinterpret_cast<entry_point_t>(
-            dlsym(lib.get(), LIBFUNC_DETAIL_EP_COMMON_NAME_STRING));
-#endif
-
-        if (dlerror() != NULL || ep == NULL) {
-            throw exceptions::CannotLoadEntryPoint(n);
-        }
-        libfunc_ep_return_t result = (*ep)(opaque);
-        if (result != LIBFUNC_RETURN_SUCCESS) {
-            throw exceptions::PluginEntryPointFailed(n);
-        }
+        convertAndCallEntryPoint(n, raw_ep, opaque);
     }
 
     return PluginHandle(lib);

--- a/tests/cplusplus/LoadTest.cpp
+++ b/tests/cplusplus/LoadTest.cpp
@@ -36,6 +36,10 @@
 
 using std::string;
 
+// loading from the global symbol table is only implemented currently in the libdl path
+// @todo implement global symbol table plugin loading in the win32 path and remove this ifdef
+#ifdef LIBFUNC_DL_LIBDL
+
 LIBFUNC_PLUGIN_NO_PARAM(com_sensics_libfunc_tests_staticplugin) {
     return LIBFUNC_RETURN_SUCCESS;
 }
@@ -43,6 +47,8 @@ LIBFUNC_PLUGIN_NO_PARAM(com_sensics_libfunc_tests_staticplugin) {
 TEST(load_static_plugin, load_from_global) {
     ASSERT_NO_THROW((libfunc::loadPluginByName("com_sensics_libfunc_tests_staticplugin", NULL)));
 }
+
+#endif
 
 TEST(load_dummy_plugin, cstr_name_null_data) {
     ASSERT_NO_THROW((libfunc::loadPluginByName("DummyPlugin", NULL)));

--- a/tests/cplusplus/LoadTest.cpp
+++ b/tests/cplusplus/LoadTest.cpp
@@ -26,6 +26,7 @@
 
 // Internal Includes
 #include <libfunctionality/LoadPlugin.h>
+#include <libfunctionality/PluginInterface.h>
 
 // Library/third-party includes
 #include "gtest/gtest.h"
@@ -34,6 +35,14 @@
 #include <string>
 
 using std::string;
+
+LIBFUNC_PLUGIN_NO_PARAM(com_sensics_libfunc_tests_staticplugin) {
+    return LIBFUNC_RETURN_SUCCESS;
+}
+
+TEST(load_static_plugin, load_from_global) {
+    ASSERT_NO_THROW((libfunc::loadPluginByName("com_sensics_libfunc_tests_staticplugin", NULL)));
+}
 
 TEST(load_dummy_plugin, cstr_name_null_data) {
     ASSERT_NO_THROW((libfunc::loadPluginByName("DummyPlugin", NULL)));


### PR DESCRIPTION
This change first exports the plugin's unique entry point so it can be loaded with dlsym, and also changes `loadPluginByName` to make an attempt to load a plugin's unique entry point symbol from the global symbol table before attempting to load the plugin file itself. This allows the function to work in places where the plugin is pre-loaded into the application (either statically linked or the .so is explicitly loaded beforehand, as on Android).